### PR TITLE
Fixed redirect in README to Contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,4 +148,4 @@ Here you can find out more about `MPICH`: [https://www.mpich.org/](https://www.m
     |   |-- page-rank.cpp
 ### Note
 > Information about Functions in main is provided in [README.md](src/README.md) <br>
-> For contributing to this repo kindly go through the guidelines provided in [Contributing.md](src/Contributing.md)
+> For contributing to this repo kindly go through the guidelines provided in [Contributing.md](Contributing.md)


### PR DESCRIPTION
The link for the contributing.md file was wrong.

The contributing.md was renamed in this commit daaed414df31c8524c5cc3eb69da5c791e6bc412
From src/Contributing.md -> Contributing.md
The change wasn't reflected in the README.md file redirect, leading to a 404-Page Not Found error when clicking on the Contributing.md link
